### PR TITLE
feature: json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_repr",
  "sha3 0.10.8",
  "tokio",
  "zksync_types",
@@ -4851,6 +4852,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "colored",
  "crypto",
  "ethers",
+ "gag",
  "hex",
  "once_cell",
  "primitive-types 0.12.2",
@@ -2052,6 +2053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+dependencies = [
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
+dependencies = [
+ "filedescriptor",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,6 @@ sha3 = "*"
 once_cell = "1.7"
 primitive-types = "0.12.2"
 
+gag = "1.0.0"
+
 crypto = { path = "./crypto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ hex = "*"
 bincode = "*"
 colored = "2.0"
 serde_json = "*"
+serde_repr = "0.1.17"
 serde = {version = "1", features = ["derive"]}
 clap = { version = "4.2.4", features = ["derive"] }
 anyhow = "*"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,30 @@ cargo run -- --batch 109939 --network mainnet --l1-rpc https://rpc.ankr.com/eth 
 --network - Along with batch number, defines if you want to verify a proof for Era testnet or mainnet. It defaults to mainnet. Accepts "mainnet" or "testnet"
 --l1-rpc - The RPC url required to pull data from L1.
 --update-verification-key - Specifes if the verification key should be updated from [github](https://github.com/matter-labs/era-contracts/blob/main/tools/data/scheduler_key.json).
+--json - Flag to specify if the output should be in json. Note that all the usual std out prints are silenced.
 ```
+
+## Error Codes
+
+Below is a list of the error codes that can be seen in the json output of the cli tool:
+- 0 => `Success`
+- 1 => `InvalidNetwork`
+- 2 => `NoRPCProvided`
+- 3 => `FailedToDeconstruct`
+- 4 => `FailedToGetDataFromL1`
+- 5 => `FailedToFindCommitTxn`
+- 6 => `InvalidLog`
+- 7 => `FailedToGetTransactionReceipt`
+- 8 => `FailedToGetBatchCommitment`
+- 9 => `ProofDoesntExist`
+- 10 => `FailedToFindProveTxn`
+- 11 => `InvalidTupleTypes`
+- 12 => `FailedToCallRPC`
+- 13 => `VerificationKeyHashMismatch`
+- 14 => `FailedToDownloadVerificationKey`
+- 15=> `FailedToWriteVerificationKeyToDisk`
+- 16 => `ProofVerificationFailed`
+
 # Future plans
 
 Currently this CLI verification keys are hardcoded or pulled from github, but the plan is to extend this tool to:

--- a/src/block_header.rs
+++ b/src/block_header.rs
@@ -49,9 +49,18 @@ pub fn parse_aux_data(func: &Function, calldata: &[u8]) -> Result<BlockAuxilaryO
         return Err(StatusCode::FailedToDeconstruct);
     };
 
-    let [abi::Token::Uint(_batch_number), abi::Token::Uint(_timestamp), abi::Token::Uint(_index_repeated_storage_changes), abi::Token::FixedBytes(_new_state_root), abi::Token::Uint(_number_l1_txns), abi::Token::FixedBytes(_priority_operations_hash), abi::Token::FixedBytes(bootloader_contents_hash), abi::Token::FixedBytes(event_queue_state_hash), abi::Token::Bytes(sys_logs), abi::Token::Bytes(_total_pubdata)] =
-        committed_batch.as_slice()
-    else {
+    let [
+        abi::Token::Uint(_batch_number), 
+        abi::Token::Uint(_timestamp), 
+        abi::Token::Uint(_index_repeated_storage_changes), 
+        abi::Token::FixedBytes(_new_state_root), 
+        abi::Token::Uint(_number_l1_txns), 
+        abi::Token::FixedBytes(_priority_operations_hash), 
+        abi::Token::FixedBytes(bootloader_contents_hash), 
+        abi::Token::FixedBytes(event_queue_state_hash), 
+        abi::Token::Bytes(sys_logs), 
+        abi::Token::Bytes(_total_pubdata)
+    ] = committed_batch.as_slice() else {
         return Err(StatusCode::FailedToDeconstruct);
     };
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,4 +1,3 @@
-use colored::Colorize;
 use ethers::prelude::{Provider, Http, BaseContract, Address, H256};
 use std::str::FromStr;
 
@@ -13,15 +12,6 @@ pub struct ContractConfig {
 impl ContractConfig {
     pub fn new(l1_rpc_url: String, network: String) -> Self {
         use ethers::abi::Abi;
-
-        if network != "mainnet" && network != "sepolia" && network != "testnet" {
-            panic!(
-                "Please use network name `{}`, `{}`, or `{}`",
-                "mainnet".yellow(),
-                "sepolia".yellow(),
-                "testnet".yellow()
-            );
-        }
 
         let provider =
             Provider::<Http>::try_from(l1_rpc_url).expect("Failed to connect to provider");
@@ -82,11 +72,6 @@ pub fn get_diamond_proxy_address(network: String) -> Address {
     } else if network == "testnet" {
         Address::from_str("1908e2bf4a88f91e4ef0dc72f02b8ea36bea2319").unwrap()
     } else {
-        panic!(
-            "Please use network name `{}`, `{}`, or `{}`",
-            "mainnet".yellow(),
-            "sepolia".yellow(),
-            "testnet".yellow()
-        );
+        Address::default()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,8 @@ async fn main() {
     let network = opt.network.clone().to_string();
     let l1_rpc = opt.l1_rpc;
 
+    // Gag allows us to stop all normal std out, this is the simplest way to keep the code the same
+    // while supporting only printing the desired json
     let gag = if opt.json {
         Some(Gag::stdout().unwrap())
     } else {
@@ -198,9 +200,7 @@ async fn main() {
 
         let resp = requests::fetch_l1_data(batch_number, &network, &l1_rpc.clone().unwrap()).await;
 
-        let output: BoojumCliJsonOutput;
-
-        if let Ok(L1BatchAndProofData {
+        let output = if let Ok(L1BatchAndProofData {
             aux_output,
             scheduler_proof,
             batch_l1_data,
@@ -250,20 +250,20 @@ async fn main() {
                 println!("Failed to verify proof due to error code: {:?}", status_code);
             }
 
-            output = BoojumCliJsonOutput {
+            BoojumCliJsonOutput {
                 status_code,
                 batch_number,
                 data
-            };     
+            }
         } else {
             let status_code = resp.unwrap_err();
-            output = BoojumCliJsonOutput {
+            println!("Failed to verify proof due to error code: {:?}", status_code);
+            BoojumCliJsonOutput {
                 status_code: status_code.clone(),
                 batch_number,
                 data: None
-            };
-            println!("Failed to verify proof due to error code: {:?}", status_code);
-        }
+            }
+        };
 
         if let Some(gag) = gag {
             drop(gag);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::{fs::File, process};
 
 mod contract;
 mod inputs;
+mod outputs;
 mod requests;
 mod snark_wrapper_verifier;
 mod utils;
@@ -51,11 +52,14 @@ struct Cli {
     /// Batch number to check proof for
     network: String,
     #[arg(long)]
-    // RPC endpoint to use to fetch L1 information
+    /// RPC endpoint to use to fetch L1 information
     l1_rpc: Option<String>,
-    // Bool to request updating verification key
+    /// Bool to request updating verification key
     #[arg(long)]
     update_verification_key: Option<bool>,
+    /// Flag to print output as json
+    #[arg(long)]
+    json: bool,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -151,8 +155,10 @@ async fn main() {
     let network = opt.network.clone().to_string();
     let l1_rpc = opt.l1_rpc;
 
+    let is_output_json = opt.json;
+
     if network != "mainnet" && network != "sepolia" && network != "testnet" {
-        println!(
+        let msg = format!(
             "Please use network name `{}`, `{}`, or `{}`",
             "mainnet".yellow(),
             "sepolia".yellow(),
@@ -205,8 +211,6 @@ async fn main() {
 
         println!("\n");
     };
-
-    println!("\n");
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ async fn main() {
 
         if gag.is_some() {
             drop(gag.unwrap());
-            print_json(StatusCode::InvalidNetwork);
+            print_json(StatusCode::InvalidNetwork, batch_number);
             return;
         }
     }
@@ -190,7 +190,7 @@ async fn main() {
 
         if gag.is_some() {
             drop(gag.unwrap());
-            print_json(StatusCode::InvalidNetwork);
+            print_json(StatusCode::InvalidNetwork, batch_number);
             return;
         }
     } else {
@@ -252,12 +252,14 @@ async fn main() {
 
             output = BoojumCliJsonOutput {
                 status_code,
+                batch_number,
                 data
             };     
         } else {
             let status_code = resp.unwrap_err();
             output = BoojumCliJsonOutput {
                 status_code: status_code.clone(),
+                batch_number,
                 data: None
             };
             println!("Failed to verify proof due to error code: {:?}", status_code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use circuit_definitions::circuit_definitions::recursion_layer::scheduler::Concre
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
+use gag::Gag;
 use serde::Deserialize;
 use std::io::Read;
 use std::{fs::File, process};
@@ -18,9 +19,10 @@ mod utils;
 
 use crate::contract::ContractConfig;
 use crate::inputs::generate_inputs;
+use crate::outputs::{print_json, StatusCode, BoojumCliJsonOutput, DataJsonOutput, construct_vk_output};
 use crate::requests::L1BatchAndProofData;
 use crate::snark_wrapper_verifier::{
-    generate_solidity_test, L1BatchProofForL1, verify_snark_from_storage, verify_snark,
+    generate_solidity_test, verify_snark, verify_snark_from_storage, L1BatchProofForL1,
 };
 use crate::utils::update_verification_key_if_needed;
 pub mod block_header;
@@ -145,7 +147,7 @@ async fn main() {
             Commands::GenerateSolidityTest(args) => generate_solidity_test(&args).await.err(),
         };
         if let Some(error) = result {
-            println!("Command failed: {}", error);
+            println!("Command failed: {:?}", error);
             process::exit(1);
         }
         return;
@@ -155,16 +157,25 @@ async fn main() {
     let network = opt.network.clone().to_string();
     let l1_rpc = opt.l1_rpc;
 
-    let is_output_json = opt.json;
+    let gag = if opt.json {
+        Some(Gag::stdout().unwrap())
+    } else {
+        None
+    };
 
     if network != "mainnet" && network != "sepolia" && network != "testnet" {
-        let msg = format!(
+        println!(
             "Please use network name `{}`, `{}`, or `{}`",
             "mainnet".yellow(),
             "sepolia".yellow(),
             "testnet".yellow()
         );
-        return;
+
+        if gag.is_some() {
+            drop(gag.unwrap());
+            print_json(StatusCode::InvalidNetwork);
+            return;
+        }
     }
 
     update_verification_key_if_needed(opt.update_verification_key).await;
@@ -176,40 +187,86 @@ async fn main() {
             "Skipping building batch information from Ethereum as no RPC url was provided."
                 .yellow()
         );
+
+        if gag.is_some() {
+            drop(gag.unwrap());
+            print_json(StatusCode::InvalidNetwork);
+            return;
+        }
     } else {
         let contract = ContractConfig::new(l1_rpc.clone().unwrap(), network.clone());
 
-        let L1BatchAndProofData {
+        let resp = requests::fetch_l1_data(batch_number, &network, &l1_rpc.clone().unwrap()).await;
+
+        let output: BoojumCliJsonOutput;
+
+        if let Ok(L1BatchAndProofData {
             aux_output,
             scheduler_proof,
             batch_l1_data,
             verifier_params,
             block_number,
-        } = requests::fetch_l1_data(batch_number, &network, &l1_rpc.clone().unwrap()).await;
+        }) = resp.clone()
+        {
+            let vk_hash = contract.get_verification_key_hash(block_number).await;
 
-        let vk_hash = contract.get_verification_key_hash(block_number).await;
+            let snark_vk_scheduler_key_file = "src/keys/scheduler_key.json";
 
-        let snark_vk_scheduler_key_file = "src/keys/scheduler_key.json";
+            let mut batch_proof = L1BatchProofForL1 {
+                aggregation_result_coords: aux_output.prepare_aggregation_result_coords(),
+                scheduler_proof,
+            };
 
-        let mut batch_proof = L1BatchProofForL1 {
-            aggregation_result_coords: aux_output.prepare_aggregation_result_coords(),
-            scheduler_proof,
-        };
+            let inputs = generate_inputs(batch_l1_data, verifier_params);
 
-        let inputs = generate_inputs(batch_l1_data, verifier_params);
+            batch_proof.scheduler_proof.inputs = inputs;
 
-        batch_proof.scheduler_proof.inputs = inputs;
+            // First, we verify that the proof itself is valid.
+            let verify_resp = verify_snark(
+                snark_vk_scheduler_key_file.to_string(),
+                batch_proof,
+                Some(vk_hash),
+            )
+            .await;
 
-        // First, we verify that the proof itself is valid.
-        verify_snark(
-            snark_vk_scheduler_key_file.to_string(),
-            batch_proof,
-            Some(vk_hash),
-        )
-        .await
-        .unwrap();
+            let mut data = None;
+            let mut status_code = StatusCode::Success;
 
-        println!("\n");
+            if let Ok((input, _, computed_vk_hash)) = verify_resp {
+                
+                
+                let mut inner_data = DataJsonOutput::from(resp.unwrap());
+                inner_data.verification_key_hash = construct_vk_output(
+                    vk_hash.to_fixed_bytes(),
+                    computed_vk_hash.to_fixed_bytes(),
+                );
+
+                inner_data.public_input = input;
+                inner_data.is_proof_valid = true;
+
+                data = Some(inner_data);
+            } else {
+                status_code = resp.err().unwrap();
+                println!("Failed to verify proof due to error code: {:?}", status_code);
+            }
+
+            output = BoojumCliJsonOutput {
+                status_code,
+                data
+            };     
+        } else {
+            let status_code = resp.unwrap_err();
+            output = BoojumCliJsonOutput {
+                status_code: status_code.clone(),
+                data: None
+            };
+            println!("Failed to verify proof due to error code: {:?}", status_code);
+        }
+
+        if let Some(gag) = gag {
+            drop(gag);
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+        }
     };
 }
 
@@ -221,6 +278,7 @@ mod test {
     use zksync_types::H256;
 
     use super::*;
+    use block_header::VerifierParams;
     use circuit_definitions::{
         circuit_definitions::{
             base_layer::ZkSyncBaseLayerStorage,
@@ -231,7 +289,6 @@ mod test {
     };
     use colored::Colorize;
     use std::str::FromStr;
-    use block_header::VerifierParams;
 
     #[test]
     fn test_scheduler_proof() {
@@ -240,7 +297,7 @@ mod test {
 
     #[tokio::test]
     async fn test_local_proof_v3() {
-        let (public_input, _) = verify_snark_from_storage(&VerifySnarkWrapperArgs {
+        let (public_input, _, _) = verify_snark_from_storage(&VerifySnarkWrapperArgs {
             l1_batch_proof_file: "example_proofs/snark_wrapper/v3/l1_batch_proof_1.bin".to_string(),
             snark_vk_scheduler_key_file:
                 "example_proofs/snark_wrapper/v3/snark_verification_scheduler_key.json".to_string(),
@@ -285,9 +342,17 @@ mod test {
         };
 
         let verifier_params = VerifierParams {
-            recursion_node_level_vk_hash: H256::from_str("5a3ef282b21e12fe1f4438e5bb158fc5060b160559c5158c6389d62d9fe3d080").unwrap().to_fixed_bytes(),
-            recursion_leaf_level_vk_hash: H256::from_str("14628525c227822148e718ca1138acfc6d25e759e19452455d89f7f610c3dcb8").unwrap().to_fixed_bytes(),
-            recursion_circuits_set_vk_hash: [0u8; 32]
+            recursion_node_level_vk_hash: H256::from_str(
+                "5a3ef282b21e12fe1f4438e5bb158fc5060b160559c5158c6389d62d9fe3d080",
+            )
+            .unwrap()
+            .to_fixed_bytes(),
+            recursion_leaf_level_vk_hash: H256::from_str(
+                "14628525c227822148e718ca1138acfc6d25e759e19452455d89f7f610c3dcb8",
+            )
+            .unwrap()
+            .to_fixed_bytes(),
+            recursion_circuits_set_vk_hash: [0u8; 32],
         };
 
         let result = generate_inputs(l1_data, verifier_params);

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,19 +1,14 @@
 use std::process;
 
 use crate::block_header::{BlockAuxilaryOutput, VerifierParams};
-use crate::requests::BatchL1Data;
+use crate::requests::{BatchL1Data, L1BatchAndProofData};
 use circuit_definitions::snark_wrapper::franklin_crypto::bellman::pairing::bn256::Fr;
 
-use serde::Serialize;
 use serde::ser::SerializeStruct;
+use serde::Serialize;
 use serde_repr::Serialize_repr;
 
-pub enum Output {
-    StdOut(&'static str),
-    Json(DataJsonOutput),
-}
-
-#[derive(Serialize_repr, PartialEq, Clone)]
+#[derive(Serialize_repr, PartialEq, Clone, Debug)]
 #[repr(u64)]
 pub enum StatusCode {
     Success = 0,
@@ -32,13 +27,23 @@ pub enum StatusCode {
     VerificationKeyHashMismatch,
     FailedToDownloadVerificationKey,
     FailedToWriteVerificationKeyToDisk,
+    ProofVerificationFailed,
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct VerificationKeyHashJsonOutput {
     layer_1_vk_hash: [u8; 32],
     computed_vk_hash: [u8; 32],
+}
+
+pub fn construct_vk_output(
+    layer_1_vk_hash: [u8; 32],
+    computed_vk_hash: [u8; 32],
+) -> VerificationKeyHashJsonOutput {
+    VerificationKeyHashJsonOutput {
+        layer_1_vk_hash,
+        computed_vk_hash,
+    }
 }
 
 #[derive(Serialize)]
@@ -51,6 +56,20 @@ pub struct DataJsonOutput {
     pub verification_key_hash: VerificationKeyHashJsonOutput,
     pub public_input: Fr,
     pub is_proof_valid: bool,
+}
+
+impl From<L1BatchAndProofData> for DataJsonOutput {
+    fn from(batch: L1BatchAndProofData) -> Self {
+        Self {
+            batch_number: batch.block_number,
+            batch_l1_data: batch.batch_l1_data,
+            aux_input: batch.aux_output,
+            verifier_params: batch.verifier_params,
+            verification_key_hash: VerificationKeyHashJsonOutput::default(),
+            public_input: Fr::default(),
+            is_proof_valid: false,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -70,8 +89,14 @@ impl Serialize for BatchL1Data {
         let _ = state.serialize_field("newStateRoot", &hex::encode(self.new_root.as_slice()));
         let _ = state.serialize_field("defaultAAHash", &hex::encode(self.default_aa_hash));
         let _ = state.serialize_field("bootloaderCodeHash", &hex::encode(self.bootloader_hash));
-        let _ = state.serialize_field("prevBatchCommitment", &hex::encode(self.prev_batch_commitment));
-        let _ = state.serialize_field("currBatchCommitment", &hex::encode(self.curr_batch_commitment));
+        let _ = state.serialize_field(
+            "prevBatchCommitment",
+            &hex::encode(self.prev_batch_commitment),
+        );
+        let _ = state.serialize_field(
+            "currBatchCommitment",
+            &hex::encode(self.curr_batch_commitment),
+        );
         state.end()
     }
 }
@@ -84,8 +109,14 @@ impl Serialize for BlockAuxilaryOutput {
         let mut state = serializer.serialize_struct("AuxInput", 4)?;
         let _ = state.serialize_field("systemLogsHash", &hex::encode(self.system_logs_hash));
         let _ = state.serialize_field("stateDiffHash", &hex::encode(self.state_diff_hash));
-        let _ = state.serialize_field("bootloaderInitialContentsHash", &hex::encode(self.bootloader_heap_initial_content_hash));
-        let _ = state.serialize_field("eventQueueStateHash", &hex::encode(self.event_queue_state_hash));
+        let _ = state.serialize_field(
+            "bootloaderInitialContentsHash",
+            &hex::encode(self.bootloader_heap_initial_content_hash),
+        );
+        let _ = state.serialize_field(
+            "eventQueueStateHash",
+            &hex::encode(self.event_queue_state_hash),
+        );
         state.end()
     }
 }
@@ -96,41 +127,46 @@ impl Serialize for VerifierParams {
         S: serde::Serializer,
     {
         let mut state = serializer.serialize_struct("VerifierParams", 3)?;
-        let _ = state.serialize_field("recursionNodeLevelVkHash", &hex::encode(self.recursion_node_level_vk_hash));
-        let _ = state.serialize_field("recursionLeafLevelVkHash", &hex::encode(self.recursion_leaf_level_vk_hash));
-        let _ = state.serialize_field("recursionCircuitsSetVkHash", &hex::encode(self.recursion_circuits_set_vk_hash));
+        let _ = state.serialize_field(
+            "recursionNodeLevelVkHash",
+            &hex::encode(self.recursion_node_level_vk_hash),
+        );
+        let _ = state.serialize_field(
+            "recursionLeafLevelVkHash",
+            &hex::encode(self.recursion_leaf_level_vk_hash),
+        );
+        let _ = state.serialize_field(
+            "recursionCircuitsSetVkHash",
+            &hex::encode(self.recursion_circuits_set_vk_hash),
+        );
         state.end()
     }
 }
 
-impl StatusCode {
-    fn print_std_out(&self, msg: &str) {
-        match self {
-            StatusCode::Success => {
-                println!("{}", msg);
-            },
-            _ => {
-                println!("{}", msg);
-                process::exit((*self).clone() as i32);       
-            }
-        }
+impl Serialize for VerificationKeyHashJsonOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VerificationKeyHash", 2)?;
+        let _ = state.serialize_field(
+            "layer1VkHash",
+            &hex::encode(self.layer_1_vk_hash),
+        );
+        let _ = state.serialize_field(
+            "computedVkHash",
+            &hex::encode(self.computed_vk_hash),
+        );
+        state.end()
     }
+}
 
-    fn print_json(&self, data: DataJsonOutput) {
-        match self {
-            StatusCode::Success => {
-                println!("{}", serde_json::to_string_pretty(&data).unwrap());
-            },
-            _ => {
-                
-            }
-        }
-    }
+pub fn print_json(status_code: StatusCode) {
+    let output = BoojumCliJsonOutput {
+        status_code: status_code.clone(),
+        data: None,
+    };
 
-    pub fn print(&self, output: Output) {
-        match output {
-            Output::StdOut(msg) => self.print_std_out(msg),
-            Output::Json(data) => self.print_json(data)
-        }
-    }
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    process::exit(status_code as i32);
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -49,7 +49,6 @@ pub fn construct_vk_output(
 #[derive(Serialize)]
 #[serde(rename = "data", rename_all = "camelCase")]
 pub struct DataJsonOutput {
-    pub batch_number: u64,
     pub batch_l1_data: BatchL1Data,
     pub aux_input: BlockAuxilaryOutput,
     pub verifier_params: VerifierParams,
@@ -61,7 +60,6 @@ pub struct DataJsonOutput {
 impl From<L1BatchAndProofData> for DataJsonOutput {
     fn from(batch: L1BatchAndProofData) -> Self {
         Self {
-            batch_number: batch.block_number,
             batch_l1_data: batch.batch_l1_data,
             aux_input: batch.aux_output,
             verifier_params: batch.verifier_params,
@@ -76,6 +74,7 @@ impl From<L1BatchAndProofData> for DataJsonOutput {
 #[serde(rename_all = "camelCase")]
 pub struct BoojumCliJsonOutput {
     pub status_code: StatusCode,
+    pub batch_number: u64,
     pub data: Option<DataJsonOutput>,
 }
 
@@ -161,9 +160,10 @@ impl Serialize for VerificationKeyHashJsonOutput {
     }
 }
 
-pub fn print_json(status_code: StatusCode) {
+pub fn print_json(status_code: StatusCode, batch_number: u64) {
     let output = BoojumCliJsonOutput {
         status_code: status_code.clone(),
+        batch_number,
         data: None,
     };
 

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,0 +1,136 @@
+use std::process;
+
+use crate::block_header::{BlockAuxilaryOutput, VerifierParams};
+use crate::requests::BatchL1Data;
+use circuit_definitions::snark_wrapper::franklin_crypto::bellman::pairing::bn256::Fr;
+
+use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde_repr::Serialize_repr;
+
+pub enum Output {
+    StdOut(&'static str),
+    Json(DataJsonOutput),
+}
+
+#[derive(Serialize_repr, PartialEq, Clone)]
+#[repr(u64)]
+pub enum StatusCode {
+    Success = 0,
+    InvalidNetwork,
+    NoRPCProvided,
+    FailedToDeconstruct,
+    FailedToGetDataFromL1,
+    FailedToFindCommitTxn,
+    InvalidLog,
+    FailedToGetTransactionReceipt,
+    FailedToGetBatchCommitment,
+    ProofDoesntExist,
+    FailedToFindProveTxn,
+    InvalidTupleTypes,
+    FailedToCallRPC,
+    VerificationKeyHashMismatch,
+    FailedToDownloadVerificationKey,
+    FailedToWriteVerificationKeyToDisk,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationKeyHashJsonOutput {
+    layer_1_vk_hash: [u8; 32],
+    computed_vk_hash: [u8; 32],
+}
+
+#[derive(Serialize)]
+#[serde(rename = "data", rename_all = "camelCase")]
+pub struct DataJsonOutput {
+    pub batch_number: u64,
+    pub batch_l1_data: BatchL1Data,
+    pub aux_input: BlockAuxilaryOutput,
+    pub verifier_params: VerifierParams,
+    pub verification_key_hash: VerificationKeyHashJsonOutput,
+    pub public_input: Fr,
+    pub is_proof_valid: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BoojumCliJsonOutput {
+    pub status_code: StatusCode,
+    pub data: Option<DataJsonOutput>,
+}
+
+impl Serialize for BatchL1Data {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("BatchL1Data", 6)?;
+        let _ = state.serialize_field("prevStateRoot", &hex::encode(self.previous_root.as_slice()));
+        let _ = state.serialize_field("newStateRoot", &hex::encode(self.new_root.as_slice()));
+        let _ = state.serialize_field("defaultAAHash", &hex::encode(self.default_aa_hash));
+        let _ = state.serialize_field("bootloaderCodeHash", &hex::encode(self.bootloader_hash));
+        let _ = state.serialize_field("prevBatchCommitment", &hex::encode(self.prev_batch_commitment));
+        let _ = state.serialize_field("currBatchCommitment", &hex::encode(self.curr_batch_commitment));
+        state.end()
+    }
+}
+
+impl Serialize for BlockAuxilaryOutput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("AuxInput", 4)?;
+        let _ = state.serialize_field("systemLogsHash", &hex::encode(self.system_logs_hash));
+        let _ = state.serialize_field("stateDiffHash", &hex::encode(self.state_diff_hash));
+        let _ = state.serialize_field("bootloaderInitialContentsHash", &hex::encode(self.bootloader_heap_initial_content_hash));
+        let _ = state.serialize_field("eventQueueStateHash", &hex::encode(self.event_queue_state_hash));
+        state.end()
+    }
+}
+
+impl Serialize for VerifierParams {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("VerifierParams", 3)?;
+        let _ = state.serialize_field("recursionNodeLevelVkHash", &hex::encode(self.recursion_node_level_vk_hash));
+        let _ = state.serialize_field("recursionLeafLevelVkHash", &hex::encode(self.recursion_leaf_level_vk_hash));
+        let _ = state.serialize_field("recursionCircuitsSetVkHash", &hex::encode(self.recursion_circuits_set_vk_hash));
+        state.end()
+    }
+}
+
+impl StatusCode {
+    fn print_std_out(&self, msg: &str) {
+        match self {
+            StatusCode::Success => {
+                println!("{}", msg);
+            },
+            _ => {
+                println!("{}", msg);
+                process::exit((*self).clone() as i32);       
+            }
+        }
+    }
+
+    fn print_json(&self, data: DataJsonOutput) {
+        match self {
+            StatusCode::Success => {
+                println!("{}", serde_json::to_string_pretty(&data).unwrap());
+            },
+            _ => {
+                process::exit((*self).clone() as i32);
+            }
+        }
+    }
+
+    pub fn print(&self, output: Output) {
+        match output {
+            Output::StdOut(msg) => self.print_std_out(msg),
+            Output::Json(data) => self.print_json(data)
+        }
+    }
+}

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -122,7 +122,7 @@ impl StatusCode {
                 println!("{}", serde_json::to_string_pretty(&data).unwrap());
             },
             _ => {
-                process::exit((*self).clone() as i32);
+                
             }
         }
     }

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -116,7 +116,7 @@ pub async fn fetch_l1_commit_data(
             .map_err(|_| StatusCode::FailedToFindCommitTxn);
 
         if commit_tx.is_err() {
-            return Err(StatusCode::FailedToFindCommitTxn);
+            return Err(commit_tx.err().unwrap());
         }
 
         let (commit_tx, _) = commit_tx.unwrap();

--- a/src/snark_wrapper_verifier.rs
+++ b/src/snark_wrapper_verifier.rs
@@ -52,6 +52,8 @@ pub async fn generate_solidity_test(args: &GenerateSolidityTestArgs) -> Result<(
 }
 
 /// Verifies a SNARK proof with a given verification key, checking the verification key hash if a value is supplied.
+/// Returns a result where the Ok value is the public input, aux witness, and computed vk hash. The error value is
+/// the status code for the failure.
 pub async fn verify_snark(
     snark_vk_scheduler_key_file: String,
     mut proof: L1BatchProofForL1,


### PR DESCRIPTION
Added the ability to have json as an output option:

`cargo run  -- --l1-rpc <rpc> --batch 331693 --network mainnet --json`

```
{
  "statusCode": 0,
  "data": {
    "batchNumber": 18719835,
    "batchL1Data": {
      "prevStateRoot": "7091a63938be2daec9896dc62d624389fa41afbed13b7fb0c4bc9725f7ff844a",
      "newStateRoot": "f18e4cd880c153e47c7289f6bed409824924168da1f40f395351c64267b2f12d",
      "defaultAAHash": "01000651c5ae96f2aab07d720439e42491bb44c6384015e3a08e32620a4d582d",
      "bootloaderCodeHash": "01000983d4ac4f797cf5c077e022f72284969b13248c2a8e9846f574bdeb5b88",
      "prevBatchCommitment": "b9971681bfa3ed414edc5639f91d9f237f8255e6062e65246e781ab35b79ffd1",
      "currBatchCommitment": "5fa1940cc52bdcd4c47b9738c228e16b8f8970ce75de500ad6880210ec8ae096"
    },
    "auxInput": {
      "systemLogsHash": "4f099d49007e6fdf54e3c24a2cf2544db46a6d56ae7cac85b4a9f4cb0ad451c5",
      "stateDiffHash": "dac5fa510a37700a44156391d8813d6af2d0480853a230cfeea89c7280eaec6e",
      "bootloaderInitialContentsHash": "a966c42c4643033ced77c8f893b14e490fb0a1849cd1e28c6cebd7eac8a435d8",
      "eventQueueStateHash": "9c55c8747a06e922a50834a6a47803dbd099c4d76c02778047982d3a709b7e09"
    },
    "verifierParams": {
      "recursionNodeLevelVkHash": "5a3ef282b21e12fe1f4438e5bb158fc5060b160559c5158c6389d62d9fe3d080",
      "recursionLeafLevelVkHash": "14628525c227822148e718ca1138acfc6d25e759e19452455d89f7f610c3dcb8",
      "recursionCircuitsSetVkHash": "0000000000000000000000000000000000000000000000000000000000000000"
    },
    "verificationKeyHash": {
      "layer1VkHash": "750d8e21be7555a6841472a5cacd24c75a7ceb34261aea61e72bb7423a7d30fc",
      "computedVkHash": "750d8e21be7555a6841472a5cacd24c75a7ceb34261aea61e72bb7423a7d30fc"
    },
    "publicInput": [
      1706706227843147499,
      17811654879834716694,
      18157096645840616503,
      1632652296
    ],
    "isProofValid": true
  }
}
```