### PR TITLE
feat: Add a "--scheduler-key" flag to override scheduler key to use

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,12 +3,17 @@ use std::env;
 /// Checks to see if the verification key exists for a given protocol version or an update has been requested and downloads it from github if needed.
 pub async fn check_verification_key(protocol_version: String) {
     let file_path = format!("src/keys/protocol_version/{}/scheduler_key.json", protocol_version);
+    // If the key for the latest protocol version is not available in this repo yet, you can always find it at https://github.com/matter-labs/era-contracts/blob/main/tools/data/scheduler_key.json
+    let err_msg = format!("Verification key for protocol version {} is missing. Please add it to the keys folder.", protocol_version);
+    ensure_key_file_exists(&file_path, &err_msg).await;
+}
+
+pub async fn ensure_key_file_exists(file_path: &String, err_msg: &String) {
     let file = env::current_dir().unwrap().join(file_path);
     let file_exists = file.exists();
 
     if !file_exists {
-        // If the key for the latest protocol version is nout available in this repo yet, you can always find it at https://github.com/matter-labs/era-contracts/blob/main/tools/data/scheduler_key.json
-        eprintln!("Verification key for protocol version {} is missing. Please add it to the keys folder.", protocol_version);
+        eprintln!("{}", err_msg);
         std::process::exit(1)
     }
 }


### PR DESCRIPTION
# Description
- This PR adds a new command line argument "--scheduler-key <FILE_PATH>"
- If it is not used or it is empty, it will go through the same flow as was used previously
- If the flag is added, it will check for the existence of the scheduler key file and use that instead of whatever is automatically retrieved

example usage:
```
cargo run -- --json --network sepolia --l1-rpc '<ETH_ARCHIVE_NODE>' --batch 5995 --scheduler-key '/User/saaqibz/scheduler_keys/scheduler_key_old.json'

cargo run -- --json --network sepolia --l1-rpc '<ETH_ARCHIVE_NODE>' --batch 5995 --scheduler-key '/User/saaqibz/scheduler_keys/scheduler_key_new.json'
```
assuming old is the key for protocol version 18 and new is version 19. The first call will work and the second call will return an ```assertion `left == right` failed``` error 